### PR TITLE
Add basic styleguide and sandbox for union components

### DIFF
--- a/js/union_organizer_styleguide.js
+++ b/js/union_organizer_styleguide.js
@@ -1,0 +1,29 @@
+/**
+ * Enhancements for the basic union styleguide.
+ */
+(function (window, document, location) {
+  var openDetails = function() {
+    var hash = location.hash.substring(1);
+    if (hash) {
+      var details = document.getElementById(hash);
+    }
+    if (details && details.tagName.toLowerCase() === 'details') {
+      details.open = true;
+    }
+  };
+  window.addEventListener('hashchange', openDetails);
+  window.addEventListener('load', openDetails);
+  window.addEventListener('DOMContentLoaded', function() {
+    var elements = document.getElementsByTagName('summary');
+    for (i = 0; i < elements.length; i++) {
+      elements[i].addEventListener('click', function(e) {
+        if (e.target.parentNode.open) {
+          history.replaceState({}, document.title, location.pathname + location.search);
+        }
+        else {
+          location.hash = e.target.parentNode.id;
+        }
+      });
+    }
+  });
+}(window, document, location));

--- a/src/Controller/StyleguideController.php
+++ b/src/Controller/StyleguideController.php
@@ -3,6 +3,7 @@
 namespace Drupal\union_organizer\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * The Union Organizer Styleguide controller.
@@ -27,6 +28,36 @@ class StyleguideController extends ControllerBase {
         'max-age' => 0,
       ]
     ];
+    return $build;
+  }
+
+  /**
+   * Returns a page for dynamically rendering demo union components.
+   *
+   * @see templates/union-component.html.twig
+   */
+  public function demo_component(String $component) {
+    if ($component) {
+      $twig_files = file_scan_directory('libraries/union/source/', '/.*\.twig$/', ['key' => 'filename']);
+      if (!array_key_exists($component . '.twig', $twig_files)) {
+        throw new NotFoundHttpException();
+      }
+
+      $build = [
+        '#theme' => 'union_component',
+        '#component' => $component,
+        '#title' => 'Union ' . $component,
+        '#attached' => [
+          'library' => [
+            'union_organizer/ilr'
+          ]
+        ],
+        '#cache' => [
+          'max-age' => 0,
+        ]
+      ];
+    }
+
     return $build;
   }
 

--- a/src/Controller/StyleguideController.php
+++ b/src/Controller/StyleguideController.php
@@ -11,13 +11,21 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class StyleguideController extends ControllerBase {
 
   /**
-   * Returns a render array for the styleguide page.
+   * Dynamically renders all demo components.
    *
    * @see templates/union-styleguide.html.twig
    */
   public function content() {
+    $demo_components = [];
+    $twig_files = file_scan_directory('libraries/union/source/', '/.*\.twig$/', ['key' => 'filename']);
+    foreach ($twig_files as $file_info) {
+      if (strpos($file_info->filename, '_') !== 0) {
+        $demo_components[$file_info->name] = $file_info->filename;
+      }
+    }
     $build = [
       '#theme' => 'union_styleguide',
+      '#components' => $demo_components,
       '#attached' => [
         'library' => [
           'union_organizer/union_organizer_styleguide',

--- a/src/Controller/StyleguideController.php
+++ b/src/Controller/StyleguideController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\union_organizer\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * The Union Organizer Styleguide controller.
+ */
+class StyleguideController extends ControllerBase {
+
+  /**
+   * Returns a render array for the styleguide page.
+   *
+   * @see templates/union-styleguide.html.twig
+   */
+  public function content() {
+    $build = [
+      '#theme' => 'union_styleguide',
+      '#attached' => [
+        'library' => [
+          'union_organizer/union_organizer_styleguide',
+          'union_organizer/ilr'
+        ]
+      ],
+      '#cache' => [
+        'max-age' => 0,
+      ]
+    ];
+    return $build;
+  }
+
+}

--- a/templates/union-component.html.twig
+++ b/templates/union-component.html.twig
@@ -1,0 +1,1 @@
+{% include '@union/'~ component ~ '.twig' %}

--- a/templates/union-styleguide.html.twig
+++ b/templates/union-styleguide.html.twig
@@ -1,0 +1,14 @@
+<details id="skin-ilr">
+<summary>ILR Skin Demo Content</summary>
+{% include '@union/demo-content.twig' %}
+</details>
+
+<details id="forms">
+<summary>Forms</summary>
+<p>Demo coming soon.</p>
+</details>
+
+<details id="messages">
+<summary>Messages</summary>
+{% include '@union/messages.twig' %}
+</details>

--- a/templates/union-styleguide.html.twig
+++ b/templates/union-styleguide.html.twig
@@ -1,14 +1,6 @@
-<details id="skin-ilr">
-<summary>ILR Skin Demo Content</summary>
-{% include '@union/demo-content.twig' %}
-</details>
-
-<details id="forms">
-<summary>Forms</summary>
-<p>Demo coming soon.</p>
-</details>
-
-<details id="messages">
-<summary>Messages</summary>
-{% include '@union/messages.twig' %}
-</details>
+{% for component, filepath in components %}
+  <details id="{{ component }}">
+    <summary>{{ component|replace('-', ' ')|capitalize }}</summary>
+    {% include '@union/' ~ filepath %}
+  </details>
+{% endfor %}

--- a/union_organizer.libraries.yml
+++ b/union_organizer.libraries.yml
@@ -1,0 +1,4 @@
+union_organizer_styleguide:
+  version: 1.x
+  js:
+    js/union_organizer_styleguide.js: {}

--- a/union_organizer.module
+++ b/union_organizer.module
@@ -72,3 +72,14 @@ function union_organizer_library_info_build() {
 
   return $libraries;
 }
+
+/**
+ * Implements hook_theme().
+ */
+function union_organizer_theme() {
+  $theme = [];
+  $theme['union_styleguide'] = [
+    'render element' => 'elements',
+  ];
+  return $theme;
+}

--- a/union_organizer.module
+++ b/union_organizer.module
@@ -79,7 +79,7 @@ function union_organizer_library_info_build() {
 function union_organizer_theme() {
   $theme = [];
   $theme['union_styleguide'] = [
-    'render element' => 'elements',
+    'variables' => ['components' => '#components'],
   ];
   $theme['union_component'] = [
     'variables' => ['component' => '#component'],

--- a/union_organizer.module
+++ b/union_organizer.module
@@ -81,5 +81,8 @@ function union_organizer_theme() {
   $theme['union_styleguide'] = [
     'render element' => 'elements',
   ];
+  $theme['union_component'] = [
+    'variables' => ['component' => '#component'],
+  ];
   return $theme;
 }

--- a/union_organizer.routing.yml
+++ b/union_organizer.routing.yml
@@ -1,0 +1,7 @@
+union_organizer.styleguide:
+  path: '/union/styleguide'
+  defaults:
+    _controller: '\Drupal\union_organizer\Controller\StyleguideController::content'
+    _title: 'Simple Union Styleguide'
+  requirements:
+    _permission: 'access content'

--- a/union_organizer.routing.yml
+++ b/union_organizer.routing.yml
@@ -5,3 +5,9 @@ union_organizer.styleguide:
     _title: 'Simple Union Styleguide'
   requirements:
     _permission: 'access content'
+union_organizer.component:
+  path: '/union/styleguide/{component}'
+  defaults:
+    _controller: '\Drupal\union_organizer\Controller\StyleguideController::demo_component'
+  requirements:
+    _permission: 'access content'


### PR DESCRIPTION
Here's that simple styleguide and sandbox for developing union components.

To test, ensure that Union Organizer is running from this branch and clear caches on the host Drupal install (registrations.ilr.test in our case). Then visit `/union/styleguide`. I added a bit of js enhancement to make the last selected section sticky on reload.

Components are added manually in `templates/union-styleguide.html.twig`. We might want to look at something more automated, but this works for now.

This branch assumes the presence of the `ilr` skin in Union, so that should probably be merged before this.